### PR TITLE
fix: 日期多选，默认日期高亮重新渲染，需要重新设置按钮状态

### DIFF
--- a/packages/earth/src/calendar/calendar.js
+++ b/packages/earth/src/calendar/calendar.js
@@ -393,6 +393,7 @@ export default defineComponent({
           fromDate: this.fromDate,
           toDate: this.toDate,
         });
+        this.confirmButtonClassName = "active";
       } else {
         const node = this.getDefaultNodeFromProps("defaultDate", [
           "single-mode",


### PR DESCRIPTION
fix: 日期多选，默认日期高亮重新渲染，需要重新设置按钮状态